### PR TITLE
Add ORCID field to the study template files

### DIFF
--- a/idr0000-study_HCS.txt
+++ b/idr0000-study_HCS.txt
@@ -28,6 +28,7 @@ Study Person Last Name	"# fill in, you can add more people, each in their own co
 Study Person First Name	# fill in																																
 Study Person Email	# fill in																																
 Study Person Address	# fill in																																
+Study Person ORCID	# fill in																																
 Study Person Roles	submitter																																
 																																	
 # Study License and Data DOI																																	

--- a/idr0000-study_nonHCS.txt
+++ b/idr0000-study_nonHCS.txt
@@ -28,6 +28,7 @@ Study Person Last Name	"# fill in, you can add more people, each in their own co
 Study Person First Name	# fill in																																
 Study Person Email	# fill in																																
 Study Person Address	# fill in																																
+Study Person ORCID	# fill in																																
 Study Person Roles	submitter																																
 																																	
 # Study License and Data DOI																																	


### PR DESCRIPTION
As discussed recently, this PR adds a new field to both the HCS and the non HCS template study files to fill the ORCID of the study contacts.

Although not mandatory, a `namedIdentifier` field is recommended in the [Datacite schema](https://schema.datacite.org/meta/kernel-4.0/) and is part of the usual DOI request workflow. Requesting it at submission time reduces the communication costs down the line when a study is ready to be published and a DOI minted.

/cc @pwalczysko @dominikl 

