### PR TITLE
Add new optional screen/experiment keys for organism

### DIFF
--- a/idr0000-study_HCS.txt
+++ b/idr0000-study_HCS.txt
@@ -61,7 +61,7 @@ Screen Technology Type Term Accession	# leave blank
 Screen Type	# choose from: primary screen, secondary screen, validation screen, or enter your own value																																
 Screen Type Term Source REF																																	
 Screen Type Term Accession																																	
-Screen Organism	# if different from Study Organism																																
+Screen Organism	# fill in if different from Study Organism, if more than one organism was studied, enter them in separate columns																																
 Screen Organism Term Source REF	NCBITaxon																																
 Screen Organism Term Accession	# leave blank																																
 Screen Comments	# if there is anything you want to say about the screen not covered elsewhere enter it here e.g. images for plate 3 are missing due to corruption																																

--- a/idr0000-study_HCS.txt
+++ b/idr0000-study_HCS.txt
@@ -61,6 +61,9 @@ Screen Technology Type Term Accession	# leave blank
 Screen Type	# choose from: primary screen, secondary screen, validation screen, or enter your own value																																
 Screen Type Term Source REF																																	
 Screen Type Term Accession																																	
+Screen Organism	# if different from Study Organism																																
+Screen Organism Term Source REF	NCBITaxon																																
+Screen Organism Term Accession	# leave blank																																
 Screen Comments	# if there is anything you want to say about the screen not covered elsewhere enter it here e.g. images for plate 3 are missing due to corruption																																
 																																	
 # Library section. The library file should be supplied separately and it should contain  the reagents description including, at the absolute minimum: reagent ID, sequences and position in the layout (= plate + position in the plate)																																	

--- a/idr0000-study_nonHCS.txt
+++ b/idr0000-study_nonHCS.txt
@@ -54,7 +54,7 @@ Experiment Example Images	# if you have a favourite image from the screen, list 
 Experiment Imaging Method	# fill in with the name of the imaging method used e.g. 3D-SIM, super resolution microscopy etc																																
 Experiment Imaging Method Term Source REF	Fbbi																																
 Experiment Imaging Method Term Accession	# look up in http://www.ebi.ac.uk/ols/ontologies/fbbi or leave blank																																
-Experiment Organism	# if different from Study Organism																																
+Experiment Organism	# fill in if different from Study Organism, if more than one organism was studied, enter them in separate columns																																
 Experiment Organism Term Source REF	NCBITaxon																																
 Experiment Organism Term Accession	# leave blank																																
 Experiment Comments	# if there is anything you would like to say about the experiment not covered elsewhere you can enter it here e.g. image X is missing, or an additional file is included																																

--- a/idr0000-study_nonHCS.txt
+++ b/idr0000-study_nonHCS.txt
@@ -54,6 +54,9 @@ Experiment Example Images	# if you have a favourite image from the screen, list 
 Experiment Imaging Method	# fill in with the name of the imaging method used e.g. 3D-SIM, super resolution microscopy etc																																
 Experiment Imaging Method Term Source REF	Fbbi																																
 Experiment Imaging Method Term Accession	# look up in http://www.ebi.ac.uk/ols/ontologies/fbbi or leave blank																																
+Experiment Organism	# if different from Study Organism																																
+Experiment Organism Term Source REF	NCBITaxon																																
+Experiment Organism Term Accession	# leave blank																																
 Experiment Comments	# if there is anything you would like to say about the experiment not covered elsewhere you can enter it here e.g. image X is missing, or an additional file is included																																
 																																	
 # assay files																																	


### PR DESCRIPTION
For multi-component multi-organism studies, it is important to assign the correct organism to the relevant screen/experiment.

This change allows to override the Study Organism key at the Screen/Experiment level